### PR TITLE
use https to avoid mixed content

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,15 +1,15 @@
       <footer class="colophon">
         <ul>
-          <li><a href="http://getbootstrap.com">Bootstrap docs</a></li>
+          <li><a href="https://getbootstrap.com">Bootstrap docs</a></li>
           <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Bootstrap issues</a></li>
           <li><a href="/feed.xml">Subscribe via RSS</a></li>
         </ul>
         <ul>
           <li>
-            <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twbs&amp;repo=bootstrap&amp;type=watch&amp;count=true" width="112" height="20"></iframe>
+            <iframe class="github-btn" src="https://ghbtns.com/github-btn.html?user=twbs&amp;repo=bootstrap&amp;type=watch&amp;count=true" width="112" height="20"></iframe>
           </li>
           <li>
-            <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twbs&amp;repo=bootstrap&amp;type=fork&amp;count=true" width="105" height="20"></iframe>
+            <iframe class="github-btn" src="https://ghbtns.com/github-btn.html?user=twbs&amp;repo=bootstrap&amp;type=fork&amp;count=true" width="105" height="20"></iframe>
           </li>
         </ul>
         <ul>
@@ -17,7 +17,7 @@
             <a href="https://twitter.com/getbootstrap" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">Follow @getbootstrap</a>
           </li>
           <li>
-            <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://twbs.github.com/bootstrap/" data-count="horizontal" data-via="getbootstrap" data-related="mdo:Creator of Twitter Bootstrap">Tweet</a>
+            <a href="https://twitter.com/share" class="twitter-share-button" data-url="https://twbs.github.com/bootstrap/" data-count="horizontal" data-via="getbootstrap" data-related="mdo:Creator of Twitter Bootstrap">Tweet</a>
           </li>
         </ul>
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,7 +17,7 @@
             <a href="https://twitter.com/getbootstrap" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">Follow @getbootstrap</a>
           </li>
           <li>
-            <a href="https://twitter.com/share" class="twitter-share-button" data-url="https://twbs.github.com/bootstrap/" data-count="horizontal" data-via="getbootstrap" data-related="mdo:Creator of Twitter Bootstrap">Tweet</a>
+            <a href="https://twitter.com/share" class="twitter-share-button" data-url="https://getbootstrap.com/bootstrap/" data-count="horizontal" data-via="getbootstrap" data-related="mdo:Creator of Twitter Bootstrap">Tweet</a>
           </li>
         </ul>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -55,11 +55,11 @@
         <a class="bs-docs-booticon" href="/">B</a>
         <h1>The Official Bootstrap Blog</h1>
         <p>
-          Announcements, discussions, and more for <a href="http://getbootstrap.com" title="Visit the Bootstrap docs">Bootstrap</a>.
+          Announcements, discussions, and more for <a href="https://getbootstrap.com" title="Visit the Bootstrap docs">Bootstrap</a>.
         </p>
       </div>
     </div>
 
     <div class="container">
 
-      <div id="carbonads-container"><div class="carbonad"><div id="azcarbon"></div><script>var z = document.createElement("script"); z.type = "text/javascript"; z.async = true; z.src = "http://engine.carbonads.com/z/32340/azcarbon_2_1_0_VERT"; var s = document.getElementsByTagName("script")[0]; s.parentNode.insertBefore(z, s);</script></div></div>
+      <div id="carbonads-container"><div class="carbonad"><div id="azcarbon"></div><script>var z = document.createElement("script"); z.type = "text/javascript"; z.async = true; z.src = "https://engine.carbonads.com/z/32340/azcarbon_2_1_0_VERT"; var s = document.getElementsByTagName("script")[0]; s.parentNode.insertBefore(z, s);</script></div></div>


### PR DESCRIPTION
The ads and github buttons weren't loading on https since they're causing mixed content.