### PR TITLE
Plugins is the new gems

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ kramdown:
 permalink:        pretty
 
 # Gems
-gems:
+plugins:
   - jekyll-paginate
 
 # Setup


### PR DESCRIPTION
`gems` config key has been defaulted to `plugins` since Jekyll 3.5, this PR intend to avoid the following deprecation warning at build time:

```
 Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```