### PR TITLE
Add missing links to Bootstrap 4 blog post

### DIFF
--- a/_posts/2018-01-18-bootstrap-4.md
+++ b/_posts/2018-01-18-bootstrap-4.md
@@ -48,11 +48,11 @@ Here’s the rundown of changes to each:
 
 - [Blog](https://getbootstrap.com/docs/4.0/examples/blog/) has been rewritten from the ground up. Gone is the two column blue header layout. We’ve built a snarky magazine-style layout with featured posts and responsive navigation.
 
-- [Dashboard](https://getbootstrap.com/docs/4.0/examples/dashboard/) has been overhauled as well to feature a live ChartJS example, includes a refreshed sidebar with [Feather icons](), and is semi-responsive.
+- [Dashboard](https://getbootstrap.com/docs/4.0/examples/dashboard/) has been overhauled as well to feature a live ChartJS example, includes a refreshed sidebar with [Feather icons](https://feathericons.com/), and is semi-responsive.
 
 - [Floating labels](https://getbootstrap.com/docs/4.0/examples/floating-labels/) is brand new and builds on our sign-in example to provide a CSS-only implementation of the floating input label. This one’s experimental and may see major changes before we bring it to Bootstrap proper.
 
-- Finally, [Offcanvas](https://getbootstrap.com/docs/4.0/examples/offcanvas/) has been rewritten from the ground up to show off a navbar-built drawer, horizontal scrolling navigation, and some custom lists built on [media component]() and utilities.
+- Finally, [Offcanvas](https://getbootstrap.com/docs/4.0/examples/offcanvas/) has been rewritten from the ground up to show off a navbar-built drawer, horizontal scrolling navigation, and some custom lists built on [media object](https://getbootstrap.com/docs/4.0/layout/media-object/) and utilities.
 
 [Cover](https://getbootstrap.com/docs/4.0/examples/cover/), [Carousel](https://getbootstrap.com/docs/4.0/examples/carousel/), [Sign-in](https://getbootstrap.com/docs/4.0/examples/sign-in/), and our [framework examples](https://getbootstrap.com/docs/4.0/examples/#framework) only saw minor updates to improve code quality and fix a few smaller bugs. Overall this was a huge update for our examples and I’m excited to iterate on these and add more in future releases.
 


### PR DESCRIPTION
Updates these two empty links in the Bootstrap 4 blog post with my best guesses:

- Feather icons
- Media component -> Media object