### PR TITLE
Always load Analytics over HTTPS

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -68,7 +68,7 @@
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
       ga('create', 'UA-146052-12', 'getbootstrap.com');
       ga('send', 'pageview');
     </script>


### PR DESCRIPTION
Safer (and sometimes faster as it saves a redirect) and the recommended way by Google.