### PR TITLE
WIP Lazyload YouTube videos

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,5 +17,9 @@
 
     </div> <!-- /close container -->
 
+    <script>
+    {% include videos.js %}
+    </script>
+
   </body>
 </html>

--- a/_includes/video.html
+++ b/_includes/video.html
@@ -1,3 +1,3 @@
-<div class="embed-responsive embed-responsive-16by9">
-  <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/{{ post.video | default: page.video }}?rel=0" title="YouTube Video" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" width="760" height="570" allowfullscreen></iframe>
+<div class="embed-responsive embed-responsive-16by9 youtube" data-embed="{{ post.video | default: page.video }}">
+  <div class="play-button"></div>
 </div>

--- a/_includes/video.html
+++ b/_includes/video.html
@@ -1,3 +1,2 @@
-<div class="embed-responsive embed-responsive-16by9 youtube" data-embed="{{ post.video | default: page.video }}">
-  <div class="play-button"></div>
-</div>
+{%- assign video_id = post.video | default: page.video -%}
+<div class="embed-responsive embed-responsive-16by9 youtube" data-embed="{{ video_id }}" style="background-image: url('https://img.youtube.com/vi/{{ video_id }}/0.jpg');"></div>

--- a/_includes/videos.js
+++ b/_includes/videos.js
@@ -1,0 +1,46 @@
+// original source:
+// https://webdesign.tutsplus.com/tutorials/how-to-lazy-load-embedded-youtube-videos--cms-26743
+
+(function() {
+  'use strict';
+
+  var videos = document.querySelectorAll('.youtube');
+  var videosLen = videos.length;
+
+  if (videosLen === 0) {
+    return;
+  }
+
+  function loadVideo(video, videoId) {
+    var iframe = document.createElement('iframe');
+
+    iframe.classList.add('embed-responsive-item');
+    iframe.setAttribute('width', '760');
+    iframe.setAttribute('height', '570');
+    iframe.setAttribute('allowfullscreen', '');
+    iframe.setAttribute('src', 'https://www.youtube.com/embed/' + videoId + '?rel=0&autoplay=1');
+
+    video.innerHTML = '';
+    video.appendChild(iframe);
+  }
+
+  function appendImg(vid, img) {
+    vid.appendChild(img);
+  }
+
+  for (var i = 0; i < videosLen; i++) {
+    var video = videos[i];
+    var id = video.getAttribute('data-embed');
+
+    if (!id) {
+      return;
+    }
+
+    var image = new Image();
+    image.src = 'https://img.youtube.com/vi/' + id + '/0.jpg';
+    image.alt = '';
+    image.addEventListener('load', appendImg.bind(null, video, image));
+
+    video.addEventListener('click', loadVideo.bind(null, video, id));
+  }
+})();

--- a/_includes/videos.js
+++ b/_includes/videos.js
@@ -1,6 +1,3 @@
-// original source:
-// https://webdesign.tutsplus.com/tutorials/how-to-lazy-load-embedded-youtube-videos--cms-26743
-
 (function() {
   'use strict';
 
@@ -15,17 +12,14 @@
     var iframe = document.createElement('iframe');
 
     iframe.classList.add('embed-responsive-item');
+    iframe.setAttribute('src', 'https://www.youtube.com/embed/' + videoId + '?rel=0&autoplay=1');
     iframe.setAttribute('width', '760');
     iframe.setAttribute('height', '570');
     iframe.setAttribute('allowfullscreen', '');
-    iframe.setAttribute('src', 'https://www.youtube.com/embed/' + videoId + '?rel=0&autoplay=1');
+    iframe.setAttribute('allow', 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture');
 
     video.innerHTML = '';
     video.appendChild(iframe);
-  }
-
-  function appendImg(vid, img) {
-    vid.appendChild(img);
   }
 
   for (var i = 0; i < videosLen; i++) {
@@ -35,11 +29,6 @@
     if (!id) {
       return;
     }
-
-    var image = new Image();
-    image.src = 'https://img.youtube.com/vi/' + id + '/0.jpg';
-    image.alt = '';
-    image.addEventListener('load', appendImg.bind(null, video, image));
 
     video.addEventListener('click', loadVideo.bind(null, video, id));
   }

--- a/_sass/_videos.scss
+++ b/_sass/_videos.scss
@@ -1,0 +1,60 @@
+.youtube {
+  background-color: #000;
+  //margin-bottom: 30px;
+  //position: relative;
+  //padding-top: 56.25%;
+  //overflow: hidden;
+  cursor: pointer;
+
+  img {
+    top: 0;
+    left: 0;
+    opacity: 0.7;
+    width: 100%;
+    height: 100%;
+  }
+
+  .play-button {
+    width: 90px;
+    height: 60px;
+    background-color: #333;
+    box-shadow: 0 0 30px rgba(0, 0, 0, 0.6);
+    z-index: 1;
+    opacity: 0.8;
+    border-radius: 6px;
+
+    &:before {
+      content: "";
+      border-style: solid;
+      border-width: 15px 0 15px 26px;
+      border-color: transparent transparent transparent #fff;
+    }
+  }
+
+  img,
+  .play-button {
+    cursor: pointer;
+  }
+
+  img,
+  iframe,
+  .play-button,
+  .play-button:before {
+    position: absolute;
+  }
+
+  .play-button,
+  .play-button:before {
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate3d(-50%, -50%, 0);
+    transform: translate3d(-50%, -50%, 0);
+  }
+
+  iframe {
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+  }
+}

--- a/_sass/_videos.scss
+++ b/_sass/_videos.scss
@@ -1,60 +1,24 @@
 .youtube {
   background-color: #000;
-  //margin-bottom: 30px;
-  //position: relative;
-  //padding-top: 56.25%;
-  //overflow: hidden;
+  position: relative;
   cursor: pointer;
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  width: 100%;
+  height: 100%;
 
-  img {
-    top: 0;
-    left: 0;
-    opacity: 0.7;
-    width: 100%;
-    height: 100%;
-  }
-
-  .play-button {
-    width: 90px;
-    height: 60px;
-    background-color: #333;
-    box-shadow: 0 0 30px rgba(0, 0, 0, 0.6);
-    z-index: 1;
-    opacity: 0.8;
-    border-radius: 6px;
-
-    &:before {
-      content: "";
-      border-style: solid;
-      border-width: 15px 0 15px 26px;
-      border-color: transparent transparent transparent #fff;
-    }
-  }
-
-  img,
-  .play-button {
-    cursor: pointer;
-  }
-
-  img,
-  iframe,
-  .play-button,
-  .play-button:before {
+  &::before {
+    content: "";
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='100%25' version='1.1' viewBox='0 0 68 48' width='100%25'%3E%3Cpath d='M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z' fill='%23212121' fill-opacity='0.8'%3E%3C/path%3E%3Cpath d='M 45,24 27,14 27,34' fill='%23fff'%3E%3C/path%3E%3C/svg%3E");
     position: absolute;
-  }
-
-  .play-button,
-  .play-button:before {
-    top: 50%;
     left: 50%;
-    -webkit-transform: translate3d(-50%, -50%, 0);
-    transform: translate3d(-50%, -50%, 0);
-  }
-
-  iframe {
-    height: 100%;
-    width: 100%;
-    top: 0;
-    left: 0;
+    top: 50%;
+    width: 68px;
+    height: 48px;
+    margin-left: -34px;
+    margin-top: -24px;
   }
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -4,3 +4,4 @@
 @import "pygments-manni";
 @import "style";
 @import "theme";
+@import "videos";


### PR DESCRIPTION
This approach is heavily based on the solution from https://webdesign.tutsplus.com/tutorials/how-to-lazy-load-embedded-youtube-videos--cms-26743

This isn't the most robust solution. I couldn't find a way to use better quality thumbs without using the API and looping through the available thumbs, also the JS code might need some improvements (@Johann-S ). And I'd like to remove the extra `div` for the button and use a pseudo selector.

Another thing we could use is the youtube-nocookie.com, not necessarily in this PR.

An alternative solution would be to use https://github.com/vb/lazyframe maybe after we tweak that.

Let me know your thoughts @mdo @Johann-S @MartijnCuppens 

Preview: https://twbs-blog-lazyload-yt.netlify.com/

Fixes #78 