### PR TITLE
Cleanup redundancy in configuration file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,45 @@
-# Dependencies
-markdown:           kramdown
-highlighter:        rouge
+# Setup
+title:          "Bootstrap Blog"
+description:    "Official blog for the Bootstrap framework."
+url:            "https://blog.getbootstrap.com"
+future:         true
+permalink:      pretty
 
-kramdown:
-  auto_ids:         true
+# Pagination
+paginate:       5
 
-# Permalinks
-permalink:          pretty
+# Sass converter configuration
+sass:
+  style:        compressed
+
+# Local Server
+host:           localhost # same as default value '127.0.0.1' but reads better
+
+# Links
+main:           "https://getbootstrap.com"
+expo:           "https://expo.getbootstrap.com"
+themes:         "https://themes.getbootstrap.com"
+
+# Social
+authors:        "Mark Otto, Jacob Thornton, and Bootstrap contributors"
+author:
+  twitter:      "getbootstrap"
+
+twitter:
+  card:         "summary_large_image"
+  username:     "getbootstrap"
+
+logo:           "/assets/img/bootstrap-social.png"
+
+# Output
+defaults:
+  - scope:
+      path:     ""
+    values:
+      image:
+        path:   "/assets/img/bootstrap-social.png" # default image
+        width:  1200
+        height: 630
 
 # Gems
 plugins:
@@ -16,25 +49,6 @@ plugins:
   - jekyll-seo-tag
   - jekyll-sitemap
 
-sass:
-    style:          compressed
-
-# Setup
-title:              "Bootstrap Blog"
-description:        "Official blog for the Bootstrap framework."
-url:                "https://blog.getbootstrap.com"
-
-# Server
-source:             "."
-destination:        ./_site
-host:               "localhost"
-port:               4000
-#baseurl:            ""
-encoding:           UTF-8
-
-paginate:           5
-future:             true
-
 exclude:
   - .sass-cache
   - .netlify
@@ -42,29 +56,3 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - README.md
-
-# Links
-main:               "https://getbootstrap.com"
-expo:               "https://expo.getbootstrap.com"
-themes:             "https://themes.getbootstrap.com"
-
-# Social
-authors:            "Mark Otto, Jacob Thornton, and Bootstrap contributors"
-author:
-  twitter:          "getbootstrap"
-
-twitter:
-  card:             "summary_large_image"
-  username:         "getbootstrap"
-
-logo:               "/assets/img/bootstrap-social.png"
-
-# Output
-defaults:
-  - scope:
-      path:         ""
-    values:
-      image:
-        path:       "/assets/img/bootstrap-social.png" # default image
-        width:      1200
-        height:     630


### PR DESCRIPTION
- Remove config keys that *do not change* defaults set by Jekyll
- Improve overall readability:
  - Move colons nearer to the "value" so that they do not appear disconnected from the key
    (trailing whitespace to the key have no effect)
  - Group *YAML lists* together