### PR TITLE
Compact Liquid conditional to calculate body class

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -40,7 +40,14 @@
     {% include analytics.html %}
 
   </head>
-  {% capture body_class %}{{ page.layout }}{% if page.body_class %} page-{{ page.body_class }}{% elsif page.slug %} page-{{ page.slug | slugify }}{% elsif page.dir %} page-{{ page.dir | slugify }}{% endif %}{% endcapture %}
+
+  {% capture body_class -%}
+    {{ page.layout }} {% if page.body_class -%} page-{{ page.body_class }}
+                      {%- elsif page.slug -%} page-{{ page.slug | slugify }}
+                      {%- elsif page.dir -%} page-{{ page.dir | slugify }}
+                      {%- endif -%}
+  {%- endcapture -%}
+
   <body class="{{ body_class }}">
 
     <div class="masthead">


### PR DESCRIPTION
The current template to compute classname assigned to the body tag is too long.

This PR proposes to use Liquid 4.0 Whitespace controller to improve template readability while maintaining current markup layout.