### PR TITLE
Disable youtube tracking

### DIFF
--- a/_includes/video.html
+++ b/_includes/video.html
@@ -2,5 +2,5 @@
   Accepts one param, "do_lazyload"
 {%- endcomment-%}
 <div class="embed-responsive embed-responsive-16by9">
-  <iframe class="embed-responsive-item{% if include.do_lazyload == true %} lazy{% endif %}" {% if include.do_lazyload == true %}data-src{% else %}src{% endif %}="https://www.youtube.com/embed/{{ post.video | default: page.video }}?rel=0" title="YouTube Video" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" width="760" height="570" allowfullscreen></iframe>
+  <iframe class="embed-responsive-item{% if include.do_lazyload == true %} lazy{% endif %}" {% if include.do_lazyload == true %}data-src{% else %}src{% endif %}="https://www.youtube-nocookie.com/embed/{{ post.video | default: page.video }}?rel=0" title="YouTube Video" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" width="760" height="570" allowfullscreen></iframe>
 </div>


### PR DESCRIPTION
Testing the nocookie domain. Should be more performant and disable tracking.

Ref. https://dri.es/how-to-remove-youtube-tracking

/CC @XhmikosR